### PR TITLE
Added Polish translations

### DIFF
--- a/portlets/scheduled-job-manager-portlet/docroot/WEB-INF/portlet.xml
+++ b/portlets/scheduled-job-manager-portlet/docroot/WEB-INF/portlet.xml
@@ -1,37 +1,41 @@
 <?xml version="1.0"?>
 
-<portlet-app xmlns="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd" version="2.0">
-	
-	<portlet>
-		<portlet-name>scheduled-job-manager</portlet-name>
-		<display-name>Scheduled Job Manager</display-name>
-		<portlet-class>
-			com.rivetlogic.quartz.portlet.QuartzSchedulerPortlet
-		</portlet-class>
-		<init-param>
-			<name>view-template</name>
-			<value>/jsp/view.jsp</value>
-		</init-param>
-		<init-param>
-			<name>help-template</name>
-			<value>/jsp/help.jsp</value>
-		</init-param>
-		<expiration-cache>0</expiration-cache>
-		<supports>
-			<mime-type>text/html</mime-type>
-			<portlet-mode>view</portlet-mode>
-			<portlet-mode>help</portlet-mode>
-		</supports>
-		<supported-locale>en</supported-locale>
+<portlet-app xmlns="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd"
+             version="2.0">
+
+    <portlet>
+        <portlet-name>scheduled-job-manager</portlet-name>
+        <display-name>Scheduled Job Manager</display-name>
+        <portlet-class>
+            com.rivetlogic.quartz.portlet.QuartzSchedulerPortlet
+        </portlet-class>
+        <init-param>
+            <name>view-template</name>
+            <value>/jsp/view.jsp</value>
+        </init-param>
+        <init-param>
+            <name>help-template</name>
+            <value>/jsp/help.jsp</value>
+        </init-param>
+        <expiration-cache>0</expiration-cache>
+        <supports>
+            <mime-type>text/html</mime-type>
+            <portlet-mode>view</portlet-mode>
+            <portlet-mode>help</portlet-mode>
+        </supports>
+        <supported-locale>en</supported-locale>
         <supported-locale>de</supported-locale>
-		<resource-bundle>content.language</resource-bundle>
-		<portlet-info>
-			<title>Scheduled Job Manager</title>
-			<short-title>Scheduled Job Manager</short-title>
-			<keywords></keywords>
-		</portlet-info>
-		<security-role-ref>
-			<role-name>administrator</role-name>
-		</security-role-ref>
-	</portlet>
+        <supported-locale>pl</supported-locale>
+        <resource-bundle>content.language</resource-bundle>
+        <portlet-info>
+            <title>Scheduled Job Manager</title>
+            <short-title>Scheduled Job Manager</short-title>
+            <keywords></keywords>
+        </portlet-info>
+        <security-role-ref>
+            <role-name>administrator</role-name>
+        </security-role-ref>
+    </portlet>
 </portlet-app>

--- a/portlets/scheduled-job-manager-portlet/docroot/WEB-INF/src/content/language_pl.properties
+++ b/portlets/scheduled-job-manager-portlet/docroot/WEB-INF/src/content/language_pl.properties
@@ -1,0 +1,22 @@
+##PORTLET
+javax.portlet.title=Menedżer Zadań
+javax.portlet.description=Menedżer Zadań prezentuje wszystkie instancje MessageListener zarejestrowane w Liferay.
+
+##POP-UP MESSAGES
+com.rivet.scheduled_job.popup.warning.msg.body=Uwaga! Nie ma możliwości ponownego wznowienia pracy menadżera z poziomu aplikacji, w tym celu wymagany będzie restart serwera.
+
+com.rivet.scheduled_job.popup.validation.msg.title=Nie wybrano żadnych zadań
+com.rivet.scheduled_job.popup.validation.msg.body=Wybierz przynajmniej jedno zadanie aby wykonać akcję.
+
+##TITLES
+scheduled.job.manager.title = Menedżer zadań
+
+##GENERAL MESSAGES
+scheduled.job.manager.empty = Usługa menedżera zadań nie działa lub żadne zadanie nie zostało zarejestrowane.
+
+##SEARCH CONTAINER COLUMN NAME
+short-name=Nazwa Zadania
+group-name=Nazwa Grupy
+previous-fire-time=Czas Ostatniego Uruchomienia
+next-fire-time=Czas Następnego Uruchomienia
+storage-type=Typ Przechowywania


### PR DESCRIPTION
Hello,
I've been using your plugin recently on Portals configured by default for Polish locale. Probably because of some Liferay bug or so-called "architectural inconsistency" (I'll try to investigate it in the future), if certain translation key is not present for current locale, there is no fallback to default bundle - key names are displayed instead. In order to fix it, I created polish bundle and indicated it within portlet.xml file. 

The application together with the change have been tested under **Liferay 6.2 CE GA6** bundled with **Tomcat 7.0.62**.

Regards,
Krzysztof Gołębiowski